### PR TITLE
fix LOWER query in API get '/:class/autocomplete'

### DIFF
--- a/lib/TableEdit/Routes/API.pm
+++ b/lib/TableEdit/Routes/API.pm
@@ -240,14 +240,21 @@ get '/:class/autocomplete' => require_login sub {
 	
 	my $search_columns = $class_info->search_columns;
 	
-	my $items = $class_info->resultset->search(
-		{
-			'-or' => {
-				map {"LOWER(".$_.")" => {'-like' => '%'.lc param('q').'%'} } @$search_columns
-			}
-		},
-		{rows => 10}
-	);
+    # lhs LIKE ?, [ bind_value ]
+    my $items = $class_info->resultset->search(
+        {
+            [
+                map {
+                    \[
+                        "LOWER($_) LIKE ?",
+                        [ { dbic_colname => $_ }, '%' . lc param('q') . '%' ]
+                     ]
+                } @$search_columns
+
+            ]
+        },
+        { rows => 10 }
+    );
 	
 	my @results;
 	for my $item ($items->all){


### PR DESCRIPTION
This should fix one of the two quoting issues with LOWER() for issue #68 but there are no tests and I don't have a TE setup to test against (not that I know where this is actually used anyway). 